### PR TITLE
hotfix: 장르 병합 처리 및 피드백 수동 동기화 기능 추가

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -191,16 +191,8 @@ export default function AdminDashboard() {
   );
 
   return (
-    <div className="h-screen overflow-y-auto bg-gray-50 p-6">
+    <div className="h-screen overflow-y-auto bg-white p-6">
       <div className="mx-auto max-w-5xl space-y-6">
-        {/* 헤더 */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            백오피스 관리자 페이지
-          </h1>
-          <p className="text-gray-600">콘텐츠 현황 및 관리</p>
-        </div>
-
         {/* 콘텐츠 분포 차트 */}
         <div className="w-full flex justify-center">
           <div className="w-full max-w-5xl">

--- a/src/components/admin/userManagement/GenreBarChart.tsx
+++ b/src/components/admin/userManagement/GenreBarChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { GenreFeedback } from '@type/admin/user';
-import { getGenreLabel } from '@utils/admin/genres';
+import { mergeGenreFeedbacks } from '@utils/admin/genres';
 import {
   BarChart,
   Bar,
@@ -25,15 +25,10 @@ interface GenreBarChartProps {
 }
 
 export default function GenreBarChart({ genres }: GenreBarChartProps) {
-  const chartData = genres
-    .map((genre) => ({
-      ...genre,
-      genreName: getGenreLabel(genre.genreType),
-      total: genre.likeCount + genre.dislikeCount + genre.uninterestedCount,
-    }))
-    .filter((g) => g.total > 0) // 총합 0인 항목 제거
-    .sort((a, b) => b.total - a.total) // 총합 기준 내림차순 정렬
-    .slice(0, 10); // 상위 10개 항목만 시각화
+  const chartData = mergeGenreFeedbacks(genres)
+    .filter((g) => g.total > 0)
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10);
 
   //튤팁을 통한 실제 값 자세히보기 컴포넌트
   const CustomTooltip = ({

--- a/src/components/admin/userManagement/GenreList.tsx
+++ b/src/components/admin/userManagement/GenreList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { GenreFeedback } from '@type/admin/user';
-import { getGenreLabel } from '@utils/admin/genres';
+import { mergeGenreFeedbacks } from '@utils/admin/genres';
 
 interface GenreListProps {
   genres: GenreFeedback[];
@@ -9,12 +9,7 @@ interface GenreListProps {
 
 //전체 목록 차트
 export default function GenreList({ genres }: GenreListProps) {
-  const chartData = genres
-    .map((g) => ({
-      ...g,
-      genreName: getGenreLabel(g.genreType),
-      total: g.likeCount + g.dislikeCount + g.uninterestedCount,
-    }))
+  const chartData = mergeGenreFeedbacks(genres)
     .filter((g) => g.total > 0)
     .sort((a, b) => b.total - a.total);
 

--- a/src/components/admin/userManagement/GenrePieChart.tsx
+++ b/src/components/admin/userManagement/GenrePieChart.tsx
@@ -3,7 +3,11 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { useMemo } from 'react';
-import { getGenreColor, getGenreLabel } from '@utils/admin/genres';
+import {
+  getGenreColor,
+  getGenreLabel,
+  mergeGenreFeedbacks,
+} from '@utils/admin/genres';
 import { GenreFeedback } from '@type/admin/user';
 
 // 좋아요,싫어요 분포 차트
@@ -14,8 +18,10 @@ interface GenrePieChartProps {
 }
 
 export default function GenrePieChart({ genres, type }: GenrePieChartProps) {
+  const mergedGenres = useMemo(() => mergeGenreFeedbacks(genres), [genres]);
+
   const filtered = useMemo(() => {
-    return genres
+    return mergedGenres
       .filter((g) => {
         const count = type === 'like' ? g.likeCount : g.dislikeCount;
         return count > 0;
@@ -26,7 +32,7 @@ export default function GenrePieChart({ genres, type }: GenrePieChartProps) {
         return bVal - aVal;
       })
       .slice(0, 10);
-  }, [genres, type]);
+  }, [mergedGenres, type]);
 
   const total = filtered.reduce(
     (sum, g) => sum + (type === 'like' ? g.likeCount : g.dislikeCount),

--- a/src/components/admin/userManagement/SummaryStats.tsx
+++ b/src/components/admin/userManagement/SummaryStats.tsx
@@ -1,6 +1,7 @@
 // ✅ components/chart/SummaryStats.tsx
 'use client';
 
+import { mergeGenreFeedbacks } from '@utils/admin/genres';
 import { UserDetail } from '@type/admin/user';
 
 interface SummaryStatsProps {
@@ -13,9 +14,9 @@ export default function SummaryStats({ userDetail }: SummaryStatsProps) {
     userDetail;
 
   // 활동한 장르 수 계산 (합이 0보다 큰 장르만 카운트)
-  const totalGenres = genres.filter(
-    (g) => g.likeCount + g.dislikeCount + g.uninterestedCount > 0,
-  ).length;
+  const mergedGenres = mergeGenreFeedbacks(genres);
+  // 활동한 장르 수 (합계가 0 초과인 것만 카운트)
+  const totalGenres = mergedGenres.filter((g) => g.total > 0).length;
 
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-4 ">

--- a/src/components/admin/userManagement/UserList.tsx
+++ b/src/components/admin/userManagement/UserList.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
 import UserCard from '@components/admin/userManagement/UserCard';
 import { User } from '@type/admin/user';
 
@@ -34,10 +28,6 @@ export default function UserList({
           <CardTitle className="text-xl font-semibold text-gray-900">
             등록된 회원 목록
           </CardTitle>
-          <CardDescription className="text-gray-500">
-            {/*나중에 count int로 주면 그때 타입 수정 및 아래 받는 값 수정 */}
-            전체 {users.length}명의 회원
-          </CardDescription>
         </div>
       </CardHeader>
 

--- a/src/components/admin/userManagement/UserManagement.tsx
+++ b/src/components/admin/userManagement/UserManagement.tsx
@@ -52,17 +52,8 @@ export default function UserManagement() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gray-50 p-6">
+    <div className="min-h-screen bg-white p-6">
       <div className="mx-auto max-w-6xl space-y-6">
-        {/* 헤더 */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            회원 정보 관리
-          </h1>
-          <p className="text-gray-600">
-            회원 현황 및 유저별 선호 장르 통계 확인
-          </p>
-        </div>
         {/* 키워드 검색*/}
         <div className="flex justify-end items-center gap-2 mb-4">
           <Label htmlFor="user-search">검색:</Label>

--- a/src/components/admin/userManagement/UserManagement.tsx
+++ b/src/components/admin/userManagement/UserManagement.tsx
@@ -7,6 +7,9 @@ import { useInfiniteUsers } from '@hooks/admin/useInfiniteScroll';
 import { Label } from '@components/ui/label';
 import { Input } from '@components/ui/input';
 import { User } from '@type/admin/user';
+import { postFeedbackFullScan } from '@lib/apis/admin/postFeedbackFullScan';
+import { Button } from '@components/ui/button';
+import { formatDateHour } from '@utils/admin/formatDate';
 
 //유저 전체 흐름 관라(검색 + 리스트 + 상세보기)
 
@@ -14,6 +17,7 @@ export default function UserManagement() {
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null);
 
   const {
     users,
@@ -23,6 +27,30 @@ export default function UserManagement() {
     loadMoreRef,
     fetchNextPage,
   } = useInfiniteUsers(searchKeyword);
+
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lastSyncedAt');
+    if (stored) {
+      setLastSyncedAt(new Date(stored));
+    }
+  }, []);
+
+  const handleManualSync = async () => {
+    try {
+      setIsSyncing(true);
+      await postFeedbackFullScan();
+      const now = new Date();
+      setLastSyncedAt(now);
+      localStorage.setItem('lastSyncedAt', now.toISOString()); // ✅ 저장
+      alert('피드백 동기화가 완료되었습니다.');
+    } catch {
+      alert('동기화에 실패했습니다.');
+    } finally {
+      setIsSyncing(false);
+    }
+  };
 
   useEffect(() => {
     if (!hasNextPage || isFetching) return;
@@ -55,15 +83,38 @@ export default function UserManagement() {
     <div className="min-h-screen bg-white p-6">
       <div className="mx-auto max-w-6xl space-y-6">
         {/* 키워드 검색*/}
-        <div className="flex justify-end items-center gap-2 mb-4">
-          <Label htmlFor="user-search">검색:</Label>
-          <Input
-            id="user-search"
-            placeholder="이름 또는 이메일"
-            value={searchKeyword}
-            onChange={(e) => setSearchKeyword(e.target.value)}
-            className="w-[240px]"
-          />
+        <div className="flex justify-between items-center gap-2 mb-4">
+          {/* 왼쪽: 동기화 버튼 */}
+
+          <div className="flex justify-between items-center gap-2">
+            <Button
+              onClick={handleManualSync}
+              disabled={isSyncing}
+              variant="default"
+              className="text-sm"
+            >
+              {isSyncing ? '동기화 중...' : '데이터 동기화'}
+            </Button>
+            {lastSyncedAt && (
+              <span className="text-xs text-gray-500 mt-1">
+                최근 수동 업데이트 시간:{' '}
+                <span className="text-blue-600 font-medium">
+                  {formatDateHour(lastSyncedAt.toISOString())}
+                </span>
+              </span>
+            )}
+          </div>
+          {/* 오른쪽: 검색 입력창 */}
+          <div className="flex items-center gap-2">
+            <Label htmlFor="user-search">검색:</Label>
+            <Input
+              id="user-search"
+              placeholder="이름 또는 이메일"
+              value={searchKeyword}
+              onChange={(e) => setSearchKeyword(e.target.value)}
+              className="w-[240px]"
+            />
+          </div>
         </div>
 
         {/* 유저 목록 */}

--- a/src/lib/apis/admin/postFeedbackFullScan.ts
+++ b/src/lib/apis/admin/postFeedbackFullScan.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@lib/apis/axiosInstance';
+
+export const postFeedbackFullScan = async (): Promise<void> => {
+  await axiosInstance.post('/api/admin/feedback/full-scan');
+};

--- a/src/types/admin/user.ts
+++ b/src/types/admin/user.ts
@@ -45,3 +45,8 @@ export type adminGenre = {
   label: string;
   id: string;
 };
+
+export interface WithTotalGenreFeedback extends GenreFeedback {
+  genreName: string;
+  total: number;
+}

--- a/src/utils/admin/genres.ts
+++ b/src/utils/admin/genres.ts
@@ -1,4 +1,8 @@
-import { adminGenre } from '@type/admin/user';
+import {
+  adminGenre,
+  GenreFeedback,
+  WithTotalGenreFeedback,
+} from '@type/admin/user';
 
 //장르 목록 정의
 export const GENRES: adminGenre[] = [
@@ -71,3 +75,40 @@ export const GENRE_COLOR_MAP: Record<string, string> = {
 
 export const getGenreColor = (raw: string) =>
   GENRE_COLOR_MAP[raw.toUpperCase().replace(/-/g, '_')] || '#CCCCCC';
+
+export const mergeGenreFeedbacks = (
+  genres: GenreFeedback[],
+): WithTotalGenreFeedback[] => {
+  const mergedMap = new Map<string, WithTotalGenreFeedback>();
+
+  for (const genre of genres) {
+    const genreName = getGenreLabel(genre.genreType); // 예: '코미디'
+
+    const existing = mergedMap.get(genreName);
+
+    if (existing) {
+      mergedMap.set(genreName, {
+        genreType: genre.genreType, // 그냥 하나만 유지
+        genreName,
+        likeCount: existing.likeCount + genre.likeCount,
+        dislikeCount: existing.dislikeCount + genre.dislikeCount,
+        uninterestedCount: existing.uninterestedCount + genre.uninterestedCount,
+        total:
+          existing.likeCount +
+          genre.likeCount +
+          existing.dislikeCount +
+          genre.dislikeCount +
+          existing.uninterestedCount +
+          genre.uninterestedCount,
+      });
+    } else {
+      mergedMap.set(genreName, {
+        ...genre,
+        genreName,
+        total: genre.likeCount + genre.dislikeCount + genre.uninterestedCount,
+      });
+    }
+  }
+
+  return Array.from(mergedMap.values());
+};


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

> ex) #이슈번호, #이슈번호

## 📝작업 내용
<h3>장르 중복 병합 처리 및 UI 개선</h3>

<ul>
  <li>
    <strong> <code>mergeGenreFeedbacks</code> 유틸 함수 구현</strong><br />
    장르 데이터 중 <code>genreType</code>은 다르지만 <code>getGenreLabel()</code> 기준으로 같은 장르명이 여러 번 등장하는 경우, 
    해당 장르들을 하나로 합쳐서 <code>likeCount</code>, <code>dislikeCount</code>, <code>uninterestedCount</code>를 합산해주는 유틸 함수 구현
  </li>

  <li>
    <strong>유틸 적용 대상 컴포넌트</strong>
    <ul>
      <li><code>GenreBarChart</code>: 중복 장르 병합 후 상위 10개 기준 막대 그래프 렌더링</li>
      <li><code>GenrePieChart</code>: 좋아요 / 싫어요 기준 병합된 장르 데이터 기반 파이 차트</li>
      <li><code>GenreList</code>: 리스트 기반 장르 피드백 표에서도 병합된 데이터 적용</li>
      <li><code>SummaryStats</code>: 중복 제외 후 실제 활동한 장르 수 계산 반영</li>
    </ul>
  </li>

  <li>
    <strong>UI 개선</strong><br />
      <li>배경 색상 흰색 통일 및 타이틀 제거 </li>
  </li>
</ul>

<hr />

<h3>수동 동기화 기능 추가 (관리자 전용)</h3>

<ul>
  <li>
    <strong> <code>postFeedbackFullScan</code> API 연동</strong><br />
    관리자가 수동으로 전체 피드백 데이터를 동기화할 수 있는 버튼 추가. 
    버튼 클릭 시 해당 API 호출 → 완료 후 <code>alert</code> 및 콘솔 로그 출력
  </li>

  <li>
    <strong>🕒 최근 동기화 시간 UI 추가</strong><br />
    동기화 버튼 아래 <code>최근 수동 업데이트 시간</code>을 표기하며, 
    <code>formatDateHour</code> 유틸을 활용해 한국어 형식으로 포맷<br />
    새로고침 이후에도 유지되도록 <code>localStorage</code> 기반 상태 관리 적용
  </li>


### 스크린샷 (선택)
<img width="1194" height="480" alt="image" src="https://github.com/user-attachments/assets/54b2d193-2d7c-414d-af77-433021a43f9f" />

## 💬리뷰 요구사항(선택)

> Reviewer가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
